### PR TITLE
fix: include field 'deprecated' in ir encoding and decoding

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/IrDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/IrDecoder.java
@@ -240,6 +240,7 @@ public class IrDecoder implements AutoCloseable
             .byteOrder(mapByteOrder(tokenDecoder.byteOrder()))
             .presence(mapPresence(tokenDecoder.presence()));
 
+        tokenBuilder.deprecated(tokenDecoder.deprecated());
         tokenBuilder.name(tokenDecoder.name());
 
         encBuilder.constValue(get(valBuffer, type, tokenDecoder.getConstValue(valArray, 0, valArray.length)));

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/IrEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/IrEncoder.java
@@ -192,7 +192,8 @@ public class IrEncoder implements AutoCloseable
             .signal(mapSignal(token.signal()))
             .primitiveType(mapPrimitiveType(type))
             .byteOrder(mapByteOrder(encoding.byteOrder()))
-            .presence(mapPresence(encoding.presence()));
+            .presence(mapPresence(encoding.presence()))
+            .deprecated(token.deprecated());
 
         try
         {


### PR DESCRIPTION
Fixes https://github.com/aeron-io/simple-binary-encoding/issues/1050