### PR TITLE
[C#] Enable dual build for netstandard2.0 & netstandard2.1

### DIFF
--- a/csharp/sbe-dll/sbe-dll.csproj
+++ b/csharp/sbe-dll/sbe-dll.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <AssemblyName>SBE</AssemblyName>
     <RootNamespace>Org.SbeTool.Sbe.Dll</RootNamespace>
@@ -37,9 +37,13 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <ItemGroup>
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+        <PackageReference Include="System.Memory" Version="4.5.3" />
+      </ItemGroup>
+    </When>
+  </Choose>
   
 </Project>


### PR DESCRIPTION
With this, a consumer of the produced NuGet package does not need to reference the obsolete package System.Memory 4.5.3 anymore, when targeting NETStandard 2.1.
This change still maintains compatibility for consumers who target NETSTandard 2.0, for anyone still running on Full .NET Framework...