### PR TITLE
[Go] Fix compile issue in generated bitset XXChoiceValues struct

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/struct/GolangGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/struct/GolangGenerator.java
@@ -1650,7 +1650,10 @@ public class GolangGenerator implements CodeGenerator
         String comma = "";
         for (final Token token : tokens)
         {
-            // In Go a composite‐literal’s elements must either be untyped constants (which are assignable to any compatible numeric type) or exactly the same type as the field. So the untyped constants, such 0, 1 works fine, but if using the primite type such as uint64{0} would not works here.
+          // In Go a composite‐literal’s elements must either be untyped constants.
+          //  (which are assignable to any compatible numeric type) or exactly the same type as the field.
+          // So the untyped constants, such 0, 1 works fine,
+          //  but if using the primite type such as uint64{0} would not works here.
             sb.append(comma)
                 .append(token.encoding().constValue().toString());
             comma = ", ";

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/struct/GolangGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/struct/GolangGenerator.java
@@ -1650,8 +1650,9 @@ public class GolangGenerator implements CodeGenerator
         String comma = "";
         for (final Token token : tokens)
         {
+            // In Go a composite‐literal’s elements must either be untyped constants (which are assignable to any compatible numeric type) or exactly the same type as the field. So the untyped constants, such 0, 1 works fine, but if using the primite type such as uint64{0} would not works here.
             sb.append(comma)
-                .append(generateLiteral(token.encoding().primitiveType(), token.encoding().constValue().toString()));
+                .append(token.encoding().constValue().toString());
             comma = ", ";
         }
 


### PR DESCRIPTION
Before the fix, the generated bitset-related code looked like this:

type PresenceMapChoiceValue uint8
type PresenceMapChoiceValues struct {
	FooField            PresenceMapChoiceValue
        BarField             PresenceMapChoiceValue
}
var PresenceMapChoice = PresenceMapChoiceValues{uint64(0), uint64(1)}

This caused a compile error:
**cannot use uint64(0) (constant 0 of type uint64) as PresenceMapChoiceValue value in struct literal
compiler[IncompatibleAssign](https://pkg.go.dev/golang.org/x/tools/internal/typesinternal#IncompatibleAssign)**
The issue is that uint64(0) cannot be directly assigned to a field of type PresenceMapChoiceValue (uint8 alias).

After the fix, the generated code is:
var PresenceMapChoice = PresenceMapChoiceValues{0, 1}

This is simple, correct, and compiles without the issues before.