### PR TITLE
[Java/C++/C#] Fix a bug in overzealous DTO validation

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/common/DtoValidationUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/common/DtoValidationUtil.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2013-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.sbe.generation.common;
+
+import uk.co.real_logic.sbe.PrimitiveType;
+import uk.co.real_logic.sbe.PrimitiveValue;
+import uk.co.real_logic.sbe.ir.Encoding;
+import uk.co.real_logic.sbe.ir.Token;
+
+/**
+ * Helpers for generating value validation code.
+ */
+public final class DtoValidationUtil
+{
+    private DtoValidationUtil()
+    {
+    }
+
+    /**
+     * What support the target language has for native integer types.
+     */
+    public enum NativeIntegerSupport
+    {
+        /**
+         * The target language supports both signed and unsigned integers natively and the generated code uses
+         * these to represent the SBE types.
+         */
+        SIGNED_AND_UNSIGNED,
+
+        /**
+         * The target language only supports signed integers natively and the generated code uses the next biggest
+         * signed integer type to represent the unsigned SBE types, except for UINT64 which is always represented
+         * as a signed long.
+         */
+        SIGNED_ONLY
+    }
+
+    /**
+     * Checks if the native type can represent values less than the valid range of the SBE type.
+     *
+     * @param fieldToken     the field token to check if it is optional.
+     * @param encoding       the encoding of the field to check the applicable minimum and null values.
+     * @param integerSupport the support for native integer types in the target language.
+     * @return true if the native type can represent values less than the valid range of the SBE type,
+     * false otherwise.
+     */
+    public static boolean nativeTypeRepresentsValuesLessThanValidRange(
+        final Token fieldToken,
+        final Encoding encoding,
+        final NativeIntegerSupport integerSupport)
+    {
+        final PrimitiveType primitiveType = encoding.primitiveType();
+        final PrimitiveValue minValue = encoding.applicableMinValue();
+
+        switch (minValue.representation())
+        {
+            case LONG:
+                final long nativeMinValue = nativeTypeMinValue(primitiveType, integerSupport);
+                final PrimitiveValue nullValue = encoding.applicableNullValue();
+                final boolean gapBefore = minValue.longValue() > nativeMinValue;
+                final boolean nullFillsGap = fieldToken.isOptionalEncoding() &&
+                    nullValue.longValue() == nativeMinValue &&
+                    minValue.longValue() == nativeMinValue + 1L;
+                return gapBefore && !nullFillsGap;
+
+            case DOUBLE:
+                switch (primitiveType)
+                {
+                    case FLOAT:
+                        return minValue.doubleValue() > -Float.MAX_VALUE;
+                    case DOUBLE:
+                        return minValue.doubleValue() > -Double.MAX_VALUE;
+                    default:
+                        throw new IllegalArgumentException(
+                            "Type did not have a double representation: " + primitiveType);
+                }
+
+            default:
+                throw new IllegalArgumentException(
+                    "Cannot understand the range of a type with representation: " + minValue.representation());
+        }
+    }
+
+    /**
+     * Checks if the native type can represent values greater than the valid range of the SBE type.
+     *
+     * @param fieldToken     the field token to check if it is optional.
+     * @param encoding       the encoding of the field to check the applicable maximum and null values.
+     * @param integerSupport the support for native integer types in the target language.
+     * @return true if the native type can represent values greater than the valid range of the SBE type,
+     * false otherwise.
+     */
+    public static boolean nativeTypeRepresentsValuesGreaterThanValidRange(
+        final Token fieldToken,
+        final Encoding encoding,
+        final NativeIntegerSupport integerSupport)
+    {
+        final PrimitiveType primitiveType = encoding.primitiveType();
+        final PrimitiveValue maxValue = encoding.applicableMaxValue();
+
+        switch (maxValue.representation())
+        {
+            case LONG:
+                final long nativeMaxValue = nativeTypeMaxValue(primitiveType, integerSupport);
+                final PrimitiveValue nullValue = encoding.applicableNullValue();
+                final boolean gapAfter = maxValue.longValue() < nativeMaxValue;
+                final boolean nullFillsGap = fieldToken.isOptionalEncoding() &&
+                    nullValue.longValue() == nativeMaxValue &&
+                    maxValue.longValue() + 1L == nativeMaxValue;
+                return gapAfter && !nullFillsGap;
+
+            case DOUBLE:
+                switch (primitiveType)
+                {
+                    case FLOAT:
+                        return maxValue.doubleValue() < Float.MAX_VALUE;
+                    case DOUBLE:
+                        return maxValue.doubleValue() < Double.MAX_VALUE;
+                    default:
+                        throw new IllegalArgumentException(
+                            "Type did not have a double representation: " + primitiveType);
+                }
+
+            default:
+                throw new IllegalArgumentException(
+                    "Cannot understand the range of a type with representation: " + maxValue.representation());
+        }
+    }
+
+    private static long nativeTypeMinValue(
+        final PrimitiveType primitiveType,
+        final NativeIntegerSupport integerSupport)
+    {
+        switch (primitiveType)
+        {
+            case CHAR:
+                return Character.MIN_VALUE;
+            case INT8:
+                return Byte.MIN_VALUE;
+            case INT16:
+                return Short.MIN_VALUE;
+            case INT32:
+                return Integer.MIN_VALUE;
+            case INT64:
+                return Long.MIN_VALUE;
+            case UINT8:
+                if (integerSupport == NativeIntegerSupport.SIGNED_ONLY)
+                {
+                    return Short.MIN_VALUE;
+                }
+                return 0L;
+            case UINT16:
+                if (integerSupport == NativeIntegerSupport.SIGNED_ONLY)
+                {
+                    return Integer.MIN_VALUE;
+                }
+                return 0L;
+            case UINT32:
+                if (integerSupport == NativeIntegerSupport.SIGNED_ONLY)
+                {
+                    return Long.MIN_VALUE;
+                }
+                return 0L;
+            case UINT64:
+                return 0L;
+            default:
+                throw new IllegalArgumentException("Type did not have a long representation: " + primitiveType);
+        }
+    }
+
+    private static long nativeTypeMaxValue(
+        final PrimitiveType primitiveType,
+        final NativeIntegerSupport integerSupport)
+    {
+        switch (primitiveType)
+        {
+            case CHAR:
+                return Character.MAX_VALUE;
+            case INT8:
+                return Byte.MAX_VALUE;
+            case INT16:
+                return Short.MAX_VALUE;
+            case INT32:
+                return Integer.MAX_VALUE;
+            case INT64:
+                return Long.MAX_VALUE;
+            case UINT8:
+                if (integerSupport == NativeIntegerSupport.SIGNED_ONLY)
+                {
+                    return Short.MAX_VALUE;
+                }
+                return 0xFFL;
+            case UINT16:
+                if (integerSupport == NativeIntegerSupport.SIGNED_ONLY)
+                {
+                    return Integer.MAX_VALUE;
+                }
+                return 0xFFFFL;
+            case UINT32:
+                if (integerSupport == NativeIntegerSupport.SIGNED_ONLY)
+                {
+                    return Long.MAX_VALUE;
+                }
+                return 0xFFFFFFFFL;
+            case UINT64:
+                return 0xFFFFFFFFFFFFFFFFL;
+            default:
+                throw new IllegalArgumentException("Type did not have a long representation: " + primitiveType);
+        }
+    }
+}

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppDtoGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppDtoGenerator.java
@@ -35,6 +35,9 @@ import java.util.stream.Collectors;
 
 import static uk.co.real_logic.sbe.generation.Generators.toLowerFirstChar;
 import static uk.co.real_logic.sbe.generation.Generators.toUpperFirstChar;
+import static uk.co.real_logic.sbe.generation.common.DtoValidationUtil.NativeIntegerSupport.SIGNED_AND_UNSIGNED;
+import static uk.co.real_logic.sbe.generation.common.DtoValidationUtil.nativeTypeRepresentsValuesGreaterThanValidRange;
+import static uk.co.real_logic.sbe.generation.common.DtoValidationUtil.nativeTypeRepresentsValuesLessThanValidRange;
 import static uk.co.real_logic.sbe.generation.cpp.CppUtil.*;
 import static uk.co.real_logic.sbe.ir.GenerationUtil.collectFields;
 import static uk.co.real_logic.sbe.ir.GenerationUtil.collectGroups;
@@ -1591,8 +1594,11 @@ public class CppDtoGenerator implements CodeGenerator
 
         String value = "value";
 
-        final boolean mustPreventLesser = !encoding.applicableMinValue().equals(encoding.primitiveType().minValue());
-        final boolean mustPreventGreater = !encoding.applicableMaxValue().equals(encoding.primitiveType().maxValue());
+        final boolean mustPreventLesser =
+            nativeTypeRepresentsValuesLessThanValidRange(fieldToken, encoding, SIGNED_AND_UNSIGNED);
+
+        final boolean mustPreventGreater =
+            nativeTypeRepresentsValuesGreaterThanValidRange(fieldToken, encoding, SIGNED_AND_UNSIGNED);
 
         if (fieldToken.isOptionalEncoding())
         {

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpDtoGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpDtoGenerator.java
@@ -35,6 +35,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static uk.co.real_logic.sbe.generation.common.DtoValidationUtil.NativeIntegerSupport.SIGNED_AND_UNSIGNED;
+import static uk.co.real_logic.sbe.generation.common.DtoValidationUtil.nativeTypeRepresentsValuesGreaterThanValidRange;
+import static uk.co.real_logic.sbe.generation.common.DtoValidationUtil.nativeTypeRepresentsValuesLessThanValidRange;
 import static uk.co.real_logic.sbe.generation.csharp.CSharpUtil.*;
 import static uk.co.real_logic.sbe.ir.GenerationUtil.collectFields;
 import static uk.co.real_logic.sbe.ir.GenerationUtil.collectGroups;
@@ -1285,7 +1288,9 @@ public class CSharpDtoGenerator implements CodeGenerator
                 .append("}\n");
         }
 
-        final boolean mustPreventLesser = !encoding.applicableMinValue().equals(encoding.primitiveType().minValue());
+        final boolean mustPreventLesser =
+            nativeTypeRepresentsValuesLessThanValidRange(fieldToken, typeToken.encoding(), SIGNED_AND_UNSIGNED);
+
         if (mustPreventLesser)
         {
             sb.append(indent).append(INDENT)
@@ -1299,7 +1304,9 @@ public class CSharpDtoGenerator implements CodeGenerator
                 .append("}\n");
         }
 
-        final boolean mustPreventGreater = !encoding.applicableMaxValue().equals(encoding.primitiveType().maxValue());
+        final boolean mustPreventGreater =
+            nativeTypeRepresentsValuesGreaterThanValidRange(fieldToken, typeToken.encoding(), SIGNED_AND_UNSIGNED);
+
         if (mustPreventGreater)
         {
             sb.append(indent).append(INDENT)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/json/JsonTokenListener.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/json/JsonTokenListener.java
@@ -15,13 +15,13 @@
  */
 package uk.co.real_logic.sbe.json;
 
-import org.agrona.DirectBuffer;
-import org.agrona.PrintBufferUtil;
 import uk.co.real_logic.sbe.PrimitiveValue;
 import uk.co.real_logic.sbe.ir.Encoding;
 import uk.co.real_logic.sbe.ir.Token;
 import uk.co.real_logic.sbe.otf.TokenListener;
 import uk.co.real_logic.sbe.otf.Types;
+import org.agrona.DirectBuffer;
+import org.agrona.PrintBufferUtil;
 
 import java.io.UnsupportedEncodingException;
 import java.util.List;
@@ -236,7 +236,7 @@ public class JsonTokenListener implements TokenListener
             final String str = charsetName != null ? new String(tempBuffer, 0, length, charsetName) :
                 PrintBufferUtil.hexDump(tempBuffer);
 
-            escape(str);
+            Types.jsonEscape(str, output);
 
             doubleQuote();
             next();
@@ -290,7 +290,7 @@ public class JsonTokenListener implements TokenListener
                         final long longValue = constOrNotPresentValue.longValue();
                         if (PrimitiveValue.NULL_VALUE_CHAR != longValue)
                         {
-                            escape(new String(new byte[]{ (byte)longValue }, characterEncoding));
+                            Types.jsonEscape(new String(new byte[] {(byte)longValue}, characterEncoding), output);
                         }
                     }
                     catch (final UnsupportedEncodingException ex)
@@ -300,7 +300,7 @@ public class JsonTokenListener implements TokenListener
                 }
                 else
                 {
-                    escape(constOrNotPresentValue.toString());
+                    Types.jsonEscape(constOrNotPresentValue.toString(), output);
                 }
 
                 doubleQuote();
@@ -371,7 +371,7 @@ public class JsonTokenListener implements TokenListener
             final byte c = buffer.getByte(index + (i * elementSize));
             if (c > 0)
             {
-                escape((char)c);
+                Types.jsonEscape((char)c, output);
             }
             else
             {
@@ -466,23 +466,5 @@ public class JsonTokenListener implements TokenListener
         }
 
         return Types.getLong(buffer, bufferIndex, typeToken.encoding());
-    }
-
-    private void escape(final String str)
-    {
-        for (int i = 0, length = str.length(); i < length; i++)
-        {
-            escape(str.charAt(i));
-        }
-    }
-
-    private void escape(final char c)
-    {
-        if ('"' == c || '\\' == c || '\b' == c || '\f' == c || '\n' == c || '\r' == c || '\t' == c)
-        {
-            output.append('\\');
-        }
-
-        output.append(c);
     }
 }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/otf/Types.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/otf/Types.java
@@ -15,10 +15,10 @@
  */
 package uk.co.real_logic.sbe.otf;
 
-import org.agrona.DirectBuffer;
 import uk.co.real_logic.sbe.PrimitiveType;
 import uk.co.real_logic.sbe.PrimitiveValue;
 import uk.co.real_logic.sbe.ir.Encoding;
+import org.agrona.DirectBuffer;
 
 import java.nio.ByteOrder;
 
@@ -27,6 +27,11 @@ import java.nio.ByteOrder;
  */
 public class Types
 {
+    private static final char[] HEX_DIGIT = {
+        '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+    };
+
     /**
      * Get an integer value from a buffer at a given index for a {@link PrimitiveType}.
      *
@@ -187,7 +192,9 @@ public class Types
         switch (encoding.primitiveType())
         {
             case CHAR:
-                sb.append('\'').append((char)buffer.getByte(index)).append('\'');
+                sb.append('\"');
+                jsonEscape((char)buffer.getByte(index), sb);
+                sb.append('\"');
                 break;
 
             case INT8:
@@ -227,15 +234,15 @@ public class Types
                 final float value = buffer.getFloat(index, encoding.byteOrder());
                 if (Float.isNaN(value))
                 {
-                    sb.append("0/0");
+                    sb.append("\"0/0\"");
                 }
                 else if (value == Float.POSITIVE_INFINITY)
                 {
-                    sb.append("1/0");
+                    sb.append("\"1/0\"");
                 }
                 else if (value == Float.NEGATIVE_INFINITY)
                 {
-                    sb.append("-1/0");
+                    sb.append("\"-1/0\"");
                 }
                 else
                 {
@@ -249,15 +256,15 @@ public class Types
                 final double value = buffer.getDouble(index, encoding.byteOrder());
                 if (Double.isNaN(value))
                 {
-                    sb.append("0/0");
+                    sb.append("\"0/0\"");
                 }
                 else if (value == Double.POSITIVE_INFINITY)
                 {
-                    sb.append("1/0");
+                    sb.append("\"1/0\"");
                 }
                 else if (value == Double.NEGATIVE_INFINITY)
                 {
-                    sb.append("-1/0");
+                    sb.append("\"-1/0\"");
                 }
                 else
                 {
@@ -280,7 +287,9 @@ public class Types
         switch (encoding.primitiveType())
         {
             case CHAR:
-                sb.append('\'').append((char)value.longValue()).append('\'');
+                sb.append('\"');
+                jsonEscape((char)value.longValue(), sb);
+                sb.append('\"');
                 break;
 
             case INT8:
@@ -299,15 +308,15 @@ public class Types
                 final float floatValue = (float)value.doubleValue();
                 if (Float.isNaN(floatValue))
                 {
-                    sb.append("0/0");
+                    sb.append("\"0/0\"");
                 }
                 else if (floatValue == Float.POSITIVE_INFINITY)
                 {
-                    sb.append("1/0");
+                    sb.append("\"1/0\"");
                 }
                 else if (floatValue == Float.NEGATIVE_INFINITY)
                 {
-                    sb.append("-1/0");
+                    sb.append("\"-1/0\"");
                 }
                 else
                 {
@@ -321,15 +330,15 @@ public class Types
                 final double doubleValue = value.doubleValue();
                 if (Double.isNaN(doubleValue))
                 {
-                    sb.append("0/0");
+                    sb.append("\"0/0\"");
                 }
                 else if (doubleValue == Double.POSITIVE_INFINITY)
                 {
-                    sb.append("1/0");
+                    sb.append("\"1/0\"");
                 }
                 else if (doubleValue == Double.NEGATIVE_INFINITY)
                 {
-                    sb.append("-1/0");
+                    sb.append("\"-1/0\"");
                 }
                 else
                 {
@@ -338,5 +347,71 @@ public class Types
                 break;
             }
         }
+    }
+
+    /**
+     * Escape a string for use in a JSON string.
+     *
+     * @param str    the string to escape
+     * @param output to append the escaped string to
+     */
+    public static void jsonEscape(final String str, final StringBuilder output)
+    {
+        for (int i = 0, length = str.length(); i < length; i++)
+        {
+            jsonEscape(str.charAt(i), output);
+        }
+    }
+
+    /**
+     * Escape a character for use in a JSON string.
+     *
+     * @param c      the character to escape
+     * @param output to append the escaped character to
+     */
+    public static void jsonEscape(final char c, final StringBuilder output)
+    {
+        if ('"' == c || '\\' == c)
+        {
+            output.append('\\');
+            output.append(c);
+        }
+        else if ('\b' == c)
+        {
+            output.append("\\b");
+        }
+        else if ('\f' == c)
+        {
+            output.append("\\f");
+        }
+        else if ('\n' == c)
+        {
+            output.append("\\n");
+        }
+        else if ('\r' == c)
+        {
+            output.append("\\r");
+        }
+        else if ('\t' == c)
+        {
+            output.append("\\t");
+        }
+        else if (c <= 0x1F || Character.isHighSurrogate(c) || Character.isLowSurrogate(c))
+        {
+            jsonUnicodeEncode(c, output);
+        }
+        else
+        {
+            output.append(c);
+        }
+    }
+
+    private static void jsonUnicodeEncode(final char c, final StringBuilder output)
+    {
+        output.append('\\').append('u')
+            .append(HEX_DIGIT[(c >>> 12) & 0x0F])
+            .append(HEX_DIGIT[(c >>> 8) & 0x0F])
+            .append(HEX_DIGIT[(c >>> 4) & 0x0F])
+            .append(HEX_DIGIT[c & 0x0F]);
     }
 }

--- a/sbe-tool/src/propertyTest/java/uk/co/real_logic/sbe/properties/DtosPropertyTest.java
+++ b/sbe-tool/src/propertyTest/java/uk/co/real_logic/sbe/properties/DtosPropertyTest.java
@@ -36,19 +36,17 @@ import org.agrona.io.DirectBufferInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.fail;
 import static uk.co.real_logic.sbe.SbeTool.JAVA_DEFAULT_DECODING_BUFFER_TYPE;
 import static uk.co.real_logic.sbe.SbeTool.JAVA_DEFAULT_ENCODING_BUFFER_TYPE;
+import static uk.co.real_logic.sbe.properties.PropertyTestUtil.addSchemaAndInputMessageFootnotes;
 
 @SuppressWarnings("ReadWriteStringCanBeUsed")
 @EnableFootnotes
@@ -64,8 +62,7 @@ public class DtosPropertyTest
     void javaDtoEncodeShouldBeTheInverseOfDtoDecode(
         @ForAll("encodedMessage") final SbeArbitraries.EncodedMessage encodedMessage,
         final Footnotes footnotes)
-        throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException,
-        IllegalAccessException
+        throws Exception
     {
         final String packageName = encodedMessage.ir().applicableNamespace();
         final InMemoryOutputManager outputManager = new InMemoryOutputManager(packageName);
@@ -94,36 +91,36 @@ public class DtosPropertyTest
                 fail("Code generation failed.", generationException);
             }
 
-            try (URLClassLoader generatedClassLoader = outputManager.compileGeneratedSources())
-            {
-                final Class<?> dtoClass =
-                    generatedClassLoader.loadClass(packageName + ".TestMessageDto");
+            final Class<?> dtoClass = outputManager.compileAndLoad(packageName + ".TestMessageDto");
 
-                final Method decodeFrom =
-                    dtoClass.getMethod("decodeFrom", DirectBuffer.class, int.class, int.class, int.class);
+            final Method decodeFrom =
+                dtoClass.getMethod("decodeFrom", DirectBuffer.class, int.class, int.class, int.class);
 
-                final Method encodeWith =
-                    dtoClass.getMethod("encodeWithHeaderWith", dtoClass, MutableDirectBuffer.class, int.class);
+            final Method encodeWith =
+                dtoClass.getMethod("encodeWithHeaderWith", dtoClass, MutableDirectBuffer.class, int.class);
 
-                final int inputLength = encodedMessage.length();
-                final ExpandableArrayBuffer inputBuffer = encodedMessage.buffer();
-                final MessageHeaderDecoder header = new MessageHeaderDecoder().wrap(inputBuffer, 0);
-                final int blockLength = header.blockLength();
-                final int actingVersion = header.version();
-                final Object dto = decodeFrom.invoke(null,
-                    encodedMessage.buffer(), MessageHeaderDecoder.ENCODED_LENGTH, blockLength, actingVersion);
-                outputBuffer.setMemory(0, outputBuffer.capacity(), (byte)0);
-                final int outputLength = (int)encodeWith.invoke(null, dto, outputBuffer, 0);
-                assertEqual(inputBuffer, inputLength, outputBuffer, outputLength);
-            }
+            final int inputLength = encodedMessage.length();
+            final DirectBuffer inputBuffer = encodedMessage.buffer();
+            final MessageHeaderDecoder header = new MessageHeaderDecoder().wrap(inputBuffer, 0);
+            final int blockLength = header.blockLength();
+            final int actingVersion = header.version();
+            final Object dto = decodeFrom.invoke(
+                null,
+                encodedMessage.buffer(), MessageHeaderDecoder.ENCODED_LENGTH, blockLength, actingVersion);
+            outputBuffer.setMemory(0, outputBuffer.capacity(), (byte)0);
+            final int outputLength = (int)encodeWith.invoke(null, dto, outputBuffer, 0);
+            assertEqual(inputBuffer, inputLength, outputBuffer, outputLength);
         }
         catch (final Throwable throwable)
         {
-            addInputFootnotes(footnotes, encodedMessage);
+            if (null != footnotes)
+            {
+                addSchemaAndInputMessageFootnotes(footnotes, encodedMessage);
 
-            final StringBuilder generatedSources = new StringBuilder();
-            outputManager.dumpSources(generatedSources);
-            footnotes.addFootnote(generatedSources.toString());
+                final StringBuilder generatedSources = new StringBuilder();
+                outputManager.dumpSources(generatedSources);
+                footnotes.addFootnote(generatedSources.toString());
+            }
 
             throw throwable;
         }
@@ -176,14 +173,12 @@ public class DtosPropertyTest
             if (!Arrays.equals(inputBytes, outputBytes))
             {
                 throw new AssertionError(
-                    "Input and output files differ\n\n" +
-                        "DIR:" + tempDir + "\n\n" +
-                        "SCHEMA:\n" + encodedMessage.schema());
+                    "Input and output files differ\n\nDIR:" + tempDir);
             }
         }
         catch (final Throwable throwable)
         {
-            addInputFootnotes(footnotes, encodedMessage);
+            addSchemaAndInputMessageFootnotes(footnotes, encodedMessage);
             addGeneratedSourcesFootnotes(footnotes, tempDir, ".cs");
 
             throw throwable;
@@ -235,14 +230,12 @@ public class DtosPropertyTest
             final byte[] outputBytes = Files.readAllBytes(tempDir.resolve("output.dat"));
             if (!Arrays.equals(inputBytes, outputBytes))
             {
-                throw new AssertionError(
-                    "Input and output files differ\n\n" +
-                    "SCHEMA:\n" + encodedMessage.schema());
+                throw new AssertionError("Input and output files differ");
             }
         }
         catch (final Throwable throwable)
         {
-            addInputFootnotes(footnotes, encodedMessage);
+            addSchemaAndInputMessageFootnotes(footnotes, encodedMessage);
             addGeneratedSourcesFootnotes(footnotes, tempDir, ".cpp");
 
             throw throwable;
@@ -316,7 +309,7 @@ public class DtosPropertyTest
     Arbitrary<SbeArbitraries.EncodedMessage> encodedMessage()
     {
         final SbeArbitraries.CharGenerationConfig config =
-            SbeArbitraries.CharGenerationConfig.jsonPrinterCompatibleAndNullTerminates();
+            SbeArbitraries.CharGenerationConfig.firstNullTerminatesCharArray();
         return SbeArbitraries.encodedMessage(config);
     }
 
@@ -342,10 +335,23 @@ public class DtosPropertyTest
         }
     }
 
+    private static String readResourceFileAsString(final String resourcePath) throws IOException
+    {
+        try (InputStream inputStream = DtosPropertyTest.class.getResourceAsStream(resourcePath))
+        {
+            if (inputStream == null)
+            {
+                throw new IllegalArgumentException("Resource not found: " + resourcePath);
+            }
+
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
     private void assertEqual(
-        final ExpandableArrayBuffer inputBuffer,
+        final DirectBuffer inputBuffer,
         final int inputLength,
-        final ExpandableArrayBuffer outputBuffer,
+        final DirectBuffer outputBuffer,
         final int outputLength)
     {
         final boolean lengthsDiffer = inputLength != outputLength;
@@ -398,16 +404,5 @@ public class DtosPropertyTest
         {
             LangUtil.rethrowUnchecked(exn);
         }
-    }
-
-    public void addInputFootnotes(final Footnotes footnotes, final SbeArbitraries.EncodedMessage encodedMessage)
-    {
-        final byte[] messageBytes = new byte[encodedMessage.length()];
-        encodedMessage.buffer().getBytes(0, messageBytes);
-        final byte[] base64EncodedMessageBytes = Base64.getEncoder().encode(messageBytes);
-
-        footnotes.addFootnote("Schema:" + System.lineSeparator() + encodedMessage.schema());
-        footnotes.addFootnote("Input Message:" + System.lineSeparator() +
-            new String(base64EncodedMessageBytes, StandardCharsets.UTF_8));
     }
 }

--- a/sbe-tool/src/propertyTest/java/uk/co/real_logic/sbe/properties/JsonPropertyTest.java
+++ b/sbe-tool/src/propertyTest/java/uk/co/real_logic/sbe/properties/JsonPropertyTest.java
@@ -46,8 +46,8 @@ public class JsonPropertyTest
     @Provide
     Arbitrary<SbeArbitraries.EncodedMessage> encodedMessage()
     {
-        final SbeArbitraries.CharGenerationMode mode =
-            SbeArbitraries.CharGenerationMode.JSON_PRINTER_COMPATIBLE;
-        return SbeArbitraries.encodedMessage(mode);
+        final SbeArbitraries.CharGenerationConfig config =
+            SbeArbitraries.CharGenerationConfig.jsonPrinterCompatibleAndNullTerminates();
+        return SbeArbitraries.encodedMessage(config);
     }
 }

--- a/sbe-tool/src/propertyTest/java/uk/co/real_logic/sbe/properties/JsonPropertyTest.java
+++ b/sbe-tool/src/propertyTest/java/uk/co/real_logic/sbe/properties/JsonPropertyTest.java
@@ -19,16 +19,23 @@ import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
+import net.jqwik.api.footnotes.EnableFootnotes;
+import net.jqwik.api.footnotes.Footnotes;
 import uk.co.real_logic.sbe.json.JsonPrinter;
 import uk.co.real_logic.sbe.properties.arbitraries.SbeArbitraries;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import static uk.co.real_logic.sbe.properties.PropertyTestUtil.addSchemaAndInputMessageFootnotes;
+
 public class JsonPropertyTest
 {
     @Property
-    void shouldGenerateValidJson(@ForAll("encodedMessage") final SbeArbitraries.EncodedMessage encodedMessage)
+    @EnableFootnotes
+    void shouldGenerateValidJson(
+        @ForAll("encodedMessage") final SbeArbitraries.EncodedMessage encodedMessage,
+        final Footnotes footnotes)
     {
         final StringBuilder output = new StringBuilder();
         final JsonPrinter printer = new JsonPrinter(encodedMessage.ir());
@@ -39,7 +46,8 @@ public class JsonPropertyTest
         }
         catch (final JSONException e)
         {
-            throw new AssertionError("Invalid JSON: " + output + "\n\nSchema:\n" + encodedMessage.schema(), e);
+            addSchemaAndInputMessageFootnotes(footnotes, encodedMessage);
+            throw new AssertionError("Invalid JSON: " + output);
         }
     }
 
@@ -47,7 +55,7 @@ public class JsonPropertyTest
     Arbitrary<SbeArbitraries.EncodedMessage> encodedMessage()
     {
         final SbeArbitraries.CharGenerationConfig config =
-            SbeArbitraries.CharGenerationConfig.jsonPrinterCompatibleAndNullTerminates();
+            SbeArbitraries.CharGenerationConfig.unrestricted();
         return SbeArbitraries.encodedMessage(config);
     }
 }

--- a/sbe-tool/src/propertyTest/java/uk/co/real_logic/sbe/properties/PropertyTestUtil.java
+++ b/sbe-tool/src/propertyTest/java/uk/co/real_logic/sbe/properties/PropertyTestUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.co.real_logic.sbe.properties;
+
+import net.jqwik.api.footnotes.Footnotes;
+import uk.co.real_logic.sbe.properties.arbitraries.SbeArbitraries;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+final class PropertyTestUtil
+{
+    private PropertyTestUtil()
+    {
+    }
+
+    static void addSchemaAndInputMessageFootnotes(
+        final Footnotes footnotes,
+        final SbeArbitraries.EncodedMessage encodedMessage)
+    {
+        final byte[] messageBytes = new byte[encodedMessage.length()];
+        encodedMessage.buffer().getBytes(0, messageBytes);
+        final byte[] base64EncodedMessageBytes = Base64.getEncoder().encode(messageBytes);
+
+        footnotes.addFootnote("Schema:" + System.lineSeparator() + encodedMessage.schema());
+        footnotes.addFootnote("Input Message:" + System.lineSeparator() +
+            new String(base64EncodedMessageBytes, StandardCharsets.UTF_8));
+    }
+}

--- a/sbe-tool/src/propertyTest/java/uk/co/real_logic/sbe/properties/schema/TestXmlSchemaWriter.java
+++ b/sbe-tool/src/propertyTest/java/uk/co/real_logic/sbe/properties/schema/TestXmlSchemaWriter.java
@@ -15,12 +15,17 @@
  */
 package uk.co.real_logic.sbe.properties.schema;
 
+import uk.co.real_logic.sbe.ir.Encoding;
 import org.agrona.collections.MutableInteger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-import uk.co.real_logic.sbe.ir.Encoding;
 
+import java.io.File;
+import java.io.StringWriter;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
@@ -28,11 +33,6 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import java.io.File;
-import java.io.StringWriter;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -355,7 +355,6 @@ public final class TestXmlSchemaWriter
         }
     }
 
-    @SuppressWarnings("EnhancedSwitchMigration")
     private static final class TypeSchemaConverter implements TypeSchemaVisitor
     {
         private final Document document;
@@ -465,7 +464,8 @@ public final class TestXmlSchemaWriter
             final Element varDataElement = createTypeElement(document, "varData", "uint8");
             varDataElement.setAttribute("length", "0");
 
-            if (varData.dataEncoding().equals(VarDataSchema.Encoding.ASCII))
+            final VarDataSchema.Encoding encoding = varData.dataEncoding();
+            if (encoding.equals(VarDataSchema.Encoding.ASCII))
             {
                 varDataElement.setAttribute("characterEncoding", "US-ASCII");
             }

--- a/sbe-tool/src/propertyTest/java/uk/co/real_logic/sbe/properties/utils/InMemoryOutputManager.java
+++ b/sbe-tool/src/propertyTest/java/uk/co/real_logic/sbe/properties/utils/InMemoryOutputManager.java
@@ -15,17 +15,14 @@
  */
 package uk.co.real_logic.sbe.properties.utils;
 
+import org.agrona.generation.CompilerUtil;
 import org.agrona.generation.DynamicPackageOutputManager;
 
-import javax.tools.*;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.net.URI;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * An implementation of {@link DynamicPackageOutputManager} that stores generated source code in memory and compiles it
@@ -34,7 +31,7 @@ import java.util.*;
 public class InMemoryOutputManager implements DynamicPackageOutputManager
 {
     private final String packageName;
-    private final Map<String, InMemoryJavaFileObject> sourceFiles = new HashMap<>();
+    private final Map<String, CharSequence> sources = new HashMap<>();
     private String packageNameOverride;
 
     public InMemoryOutputManager(final String packageName)
@@ -53,42 +50,32 @@ public class InMemoryOutputManager implements DynamicPackageOutputManager
     }
 
     /**
-     * Compile the generated sources and return a {@link URLClassLoader} that can be used to load the generated classes.
+     * Compile the generated sources and return a {@link Class} matching the supplied fully-qualified name.
      *
-     * @return a {@link URLClassLoader} that can be used to load the generated classes
+     * @param fqClassName the fully-qualified class name to compile and load.
+     * @return a {@link Class} matching the supplied fully-qualified name.
      */
-    public URLClassLoader compileGeneratedSources()
+    public Class<?> compileAndLoad(final String fqClassName)
     {
-        final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-        final StandardJavaFileManager standardFileManager = compiler.getStandardFileManager(null, null, null);
-        final InMemoryFileManager fileManager = new InMemoryFileManager(standardFileManager);
-        final JavaCompiler.CompilationTask task = compiler.getTask(
-            null,
-            fileManager,
-            null,
-            null,
-            null,
-            sourceFiles.values());
-
-        if (!task.call())
+        try
         {
-            throw new IllegalStateException("Compilation failed");
+            return CompilerUtil.compileInMemory(fqClassName, sources);
         }
-
-        final GeneratedCodeLoader classLoader = new GeneratedCodeLoader(getClass().getClassLoader());
-        classLoader.defineClasses(fileManager);
-        return classLoader;
+        catch (final Exception exception)
+        {
+            throw new RuntimeException(exception);
+        }
     }
 
     public void dumpSources(final StringBuilder builder)
     {
-        builder.append(System.lineSeparator()).append("Generated sources file count: ").append(sourceFiles.size())
+        builder.append(System.lineSeparator()).append("Generated sources file count: ").append(sources.size())
             .append(System.lineSeparator());
 
-        sourceFiles.forEach((qualifiedName, file) ->
+        sources.forEach((qualifiedName, source) ->
         {
             builder.append(System.lineSeparator()).append("Source file: ").append(qualifiedName)
-                .append(System.lineSeparator()).append(file.sourceCode)
+                .append(System.lineSeparator()).append(source)
                 .append(System.lineSeparator());
         });
     }
@@ -109,93 +96,14 @@ public class InMemoryOutputManager implements DynamicPackageOutputManager
             packageNameOverride = null;
 
             final String qualifiedName = actingPackageName + "." + name;
-            final InMemoryJavaFileObject sourceFile =
-                new InMemoryJavaFileObject(qualifiedName, getBuffer().toString());
 
-            final InMemoryJavaFileObject existingFile = sourceFiles.putIfAbsent(qualifiedName, sourceFile);
+            final String source = getBuffer().toString();
+            final CharSequence existingSource = sources.putIfAbsent(qualifiedName, source);
 
-            if (existingFile != null && !Objects.equals(existingFile.sourceCode, sourceFile.sourceCode))
+            if (null != existingSource && 0 != CharSequence.compare(existingSource, source))
             {
                 throw new IllegalStateException("Duplicate (but different) class: " + qualifiedName);
             }
-        }
-    }
-
-    static class InMemoryFileManager extends ForwardingJavaFileManager<StandardJavaFileManager>
-    {
-        private final List<InMemoryJavaFileObject> outputFiles = new ArrayList<>();
-
-        InMemoryFileManager(final StandardJavaFileManager fileManager)
-        {
-            super(fileManager);
-        }
-
-        public JavaFileObject getJavaFileForOutput(
-            final Location location,
-            final String className,
-            final JavaFileObject.Kind kind,
-            final FileObject sibling)
-        {
-            final InMemoryJavaFileObject outputFile = new InMemoryJavaFileObject(className, kind);
-            outputFiles.add(outputFile);
-            return outputFile;
-        }
-
-        public Collection<InMemoryJavaFileObject> outputFiles()
-        {
-            return outputFiles;
-        }
-    }
-
-    static class InMemoryJavaFileObject extends SimpleJavaFileObject
-    {
-        private final String sourceCode;
-        private final ByteArrayOutputStream outputStream;
-
-        InMemoryJavaFileObject(final String className, final String sourceCode)
-        {
-            super(URI.create("string:///" + className.replace('.', '/') + Kind.SOURCE.extension), Kind.SOURCE);
-            this.sourceCode = sourceCode;
-            this.outputStream = new ByteArrayOutputStream();
-        }
-
-        InMemoryJavaFileObject(final String className, final Kind kind)
-        {
-            super(URI.create("mem:///" + className.replace('.', '/') + kind.extension), kind);
-            this.sourceCode = null;
-            this.outputStream = new ByteArrayOutputStream();
-        }
-
-        public CharSequence getCharContent(final boolean ignoreEncodingErrors)
-        {
-            return sourceCode;
-        }
-
-        public ByteArrayOutputStream openOutputStream()
-        {
-            return outputStream;
-        }
-
-        public byte[] getClassBytes()
-        {
-            return outputStream.toByteArray();
-        }
-    }
-
-    static class GeneratedCodeLoader extends URLClassLoader
-    {
-        GeneratedCodeLoader(final ClassLoader parent)
-        {
-            super(new URL[0], parent);
-        }
-
-        void defineClasses(final InMemoryFileManager fileManager)
-        {
-            fileManager.outputFiles().forEach(file ->
-            {
-                final byte[] classBytes = file.getClassBytes();
-                super.defineClass(null, classBytes, 0, classBytes.length);
-            });
         }
     }
 }

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/common/DtoValidationUtilTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/common/DtoValidationUtilTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2013-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.sbe.generation.common;
+
+import uk.co.real_logic.sbe.PrimitiveType;
+import uk.co.real_logic.sbe.PrimitiveValue;
+import uk.co.real_logic.sbe.ir.Encoding;
+import uk.co.real_logic.sbe.ir.Token;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.co.real_logic.sbe.generation.common.DtoValidationUtil.nativeTypeRepresentsValuesGreaterThanValidRange;
+import static uk.co.real_logic.sbe.generation.common.DtoValidationUtil.nativeTypeRepresentsValuesLessThanValidRange;
+
+public class DtoValidationUtilTest
+{
+    @ParameterizedTest
+    @CsvSource({
+        "int8,SIGNED_AND_UNSIGNED,false,-128,-127,127,true,false",
+        "int8,SIGNED_AND_UNSIGNED,true,-128,-127,127,false,false",
+        "int8,SIGNED_ONLY,false,-128,-127,127,true,false",
+        "int8,SIGNED_ONLY,true,-128,-127,127,false,false",
+
+        "int8,SIGNED_AND_UNSIGNED,false,127,-128,126,false,true",
+        "int8,SIGNED_AND_UNSIGNED,true,127,-128,126,false,false",
+        "int8,SIGNED_ONLY,false,127,-128,126,false,true",
+        "int8,SIGNED_ONLY,true,127,-128,126,false,false",
+
+        "int8,SIGNED_ONLY,true,-128,-100,127,true,false",
+        "int8,SIGNED_ONLY,true,127,-128,100,false,true",
+
+        "int8,SIGNED_ONLY,true,0,-128,127,false,false",
+        "int8,SIGNED_ONLY,true,0,-127,127,true,false",
+        "int8,SIGNED_ONLY,true,0,-128,126,false,true",
+        "int8,SIGNED_ONLY,true,0,-127,126,true,true",
+
+        "uint8,SIGNED_AND_UNSIGNED,false,255,0,254,false,true",
+        "uint8,SIGNED_AND_UNSIGNED,true,255,0,254,false,false",
+        "uint8,SIGNED_ONLY,false,255,0,254,true,true",
+        "uint8,SIGNED_ONLY,true,255,0,254,true,true",
+
+        "float,SIGNED_AND_UNSIGNED,false,-2,-1,1,true,true",
+        "float,SIGNED_AND_UNSIGNED,true,-2,-1,1,true,true",
+        "float,SIGNED_ONLY,false,-2,-1,1,true,true",
+        "float,SIGNED_ONLY,true,-2,-1,1,true,true",
+
+        "uint64,SIGNED_AND_UNSIGNED,true,18446744073709551615,0,18446744073709551614,false,false",
+        "uint64,SIGNED_AND_UNSIGNED,true,18446744073709551615,1,18446744073709551614,true,false",
+        "uint64,SIGNED_AND_UNSIGNED,true,18446744073709551615,0,18446744073709551613,false,true",
+        "uint64,SIGNED_AND_UNSIGNED,true,18446744073709551615,1,18446744073709551613,true,true",
+        "uint64,SIGNED_ONLY,true,18446744073709551615,0,18446744073709551614,false,false",
+        "uint64,SIGNED_ONLY,true,18446744073709551615,1,18446744073709551614,true,false",
+        "uint64,SIGNED_ONLY,true,18446744073709551615,0,18446744073709551613,false,true",
+        "uint64,SIGNED_ONLY,true,18446744073709551615,1,18446744073709551613,true,true",
+    })
+    void shouldGenerateValidationBasedOnNativeRangeVersusSbeTypeRange(
+        final String type,
+        final DtoValidationUtil.NativeIntegerSupport integerSupport,
+        final boolean isOptional,
+        final String nullValue,
+        final String minValue,
+        final String maxValue,
+        final boolean shouldValidateBelow,
+        final boolean shouldValidateAbove)
+    {
+        final Token fieldToken = mock(Token.class);
+        when(fieldToken.isOptionalEncoding()).thenReturn(isOptional);
+        final Encoding encoding = mock(Encoding.class);
+        final PrimitiveType primitiveType = PrimitiveType.get(type);
+        when(encoding.primitiveType()).thenReturn(primitiveType);
+        when(encoding.applicableNullValue()).thenReturn(PrimitiveValue.parse(nullValue, primitiveType));
+        when(encoding.applicableMinValue()).thenReturn(PrimitiveValue.parse(minValue, primitiveType));
+        when(encoding.applicableMaxValue()).thenReturn(PrimitiveValue.parse(maxValue, primitiveType));
+
+        final boolean validatesBelow =
+            nativeTypeRepresentsValuesLessThanValidRange(fieldToken, encoding, integerSupport);
+
+        final boolean validatesAbove =
+            nativeTypeRepresentsValuesGreaterThanValidRange(fieldToken, encoding, integerSupport);
+
+        assertEquals(
+            shouldValidateBelow, validatesBelow,
+            shouldValidateBelow ? "should" : "should not" + " validate below");
+
+        assertEquals(
+            shouldValidateAbove, validatesAbove,
+            shouldValidateAbove ? "should" : "should not" + " validate above");
+    }
+}


### PR DESCRIPTION
Previously, in Java, the generated validation methods would not permit
the null value, even for fields with optional presence. Now, we do allow
these correctly.

In this change, I've also attempted to clean up, centralise, and test
the logic that decides when validation for a particular side of a range
needs to be included. We omit the validation when the native type cannot
represent values outside of the range.

There are still some gaps around validation, e.g., we do not validate
array values.

---

**EDIT**:

The changes above exposed some areas where the OTF JSON printing support in Java did not produce valid JSON, particularly around escaping characters (but also in the representation of some floating-point concepts and some delimiters). I've attempted to improve this area; however, I believe **there are still some gaps**. For example, when dealing with a fixed-size char array, the implementation makes no attempt to understand the character encoding. Therefore, a character set whose encoded values don't map directly onto unicode code points will have issues, e.g., Windows-1252.