### PR TITLE
[C++] add getter for schema id on the IrDecoder

### DIFF
--- a/sbe-tool/src/main/cpp/otf/IrDecoder.h
+++ b/sbe-tool/src/main/cpp/otf/IrDecoder.h
@@ -137,6 +137,10 @@ public:
         return result;
     }
 
+    int schemaId() const {
+        return m_id;
+    }
+
 protected:
     // OS specifics
     static long long getFileSize(const char *filename)


### PR DESCRIPTION
this allows for decoding a stream containing multiple schemas by having multiple IrDecoders and picking one based on the schema id.