### PR TITLE
Replaced empty array creation by Array.Empty

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -1141,7 +1141,7 @@ public class CSharpGenerator implements CodeGenerator
             generateDocumentation(indent, fieldToken),
             typeName, propName, offset,
             generateArrayFieldNotPresentCondition(fieldToken.version(),
-            indent + INDENT + INDENT, "new " + typeName + "[0]"),
+            indent + INDENT + INDENT, "System.Array.Empty<" + typeName + ">()"),
             accessOrderListenerCallDoubleIndent));
 
         sb.append(String.format("\n" +
@@ -1155,7 +1155,7 @@ public class CSharpGenerator implements CodeGenerator
             generateDocumentation(indent, fieldToken),
             typeName, propName, offset,
             generateArrayFieldNotPresentCondition(fieldToken.version(),
-            indent + INDENT + INDENT, "new " + typeName + "[0]"),
+            indent + INDENT + INDENT, "System.Array.Empty<" + typeName + ">()"),
             accessOrderListenerCall));
 
         if (typeToken.encoding().primitiveType() == PrimitiveType.CHAR)


### PR DESCRIPTION
to prevent creating any objects when not needed.

Fixes the following issue:

https://github.com/aeron-io/simple-binary-encoding/issues/1079