### PR TITLE
[C++] mark a generated function SBE_CONSTEXPR (#1077)

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -2630,9 +2630,9 @@ public class CppGenerator implements CodeGenerator
             values);
 
         sb.append(String.format("\n" +
-            indent + "    SBE_NODISCARD %1$s %2$s(const std::uint64_t index) const\n" +
+            indent + "    SBE_NODISCARD static SBE_CONSTEXPR %1$s %2$s(const std::uint64_t index)\n" +
             indent + "    {\n" +
-            indent + "        static const std::uint8_t %2$sValues[] = { %3$s, 0 };\n\n" +
+            indent + "        const std::uint8_t %2$sValues[] = { %3$s, 0 };\n\n" +
 
             indent + "        return (char)%2$sValues[index];\n" +
             indent + "    }\n",


### PR DESCRIPTION
Add some missing SBE_CONSTEXPR to the C++ generated code.