### PR TITLE
Reject negative choice values in SetType

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/SetType.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/SetType.java
@@ -223,7 +223,7 @@ public class SetType extends Type
             deprecated = Integer.parseInt(getAttributeValue(node, "deprecated", "0"));
 
             // choice values are bit positions (0, 1, 2, 3, 4, etc.) from LSB to MSB
-            if (value.longValue() >= (encodingType.size() * 8L))
+            if (value.longValue() < 0 || value.longValue() >= (encodingType.size() * 8L))
             {
                 throw new IllegalArgumentException("Choice value out of bounds: " + value.longValue());
             }

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/xml/SetTypeTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/xml/SetTypeTest.java
@@ -176,6 +176,21 @@ class SetTypeTest
     }
 
     @Test
+    void shouldThrowExceptionWhenNegativeValueSpecified()
+    {
+        final String testXmlString =
+            "<types>" +
+            "<set name=\"biOp\" encodingType=\"uint8\">" +
+            "    <choice name=\"Bit0\">0</choice>" +
+            "    <choice name=\"BitNeg\">-1</choice>" +
+            "</set>" +
+            "</types>";
+
+        assertThrows(IllegalArgumentException.class, () ->
+            parseTestXmlWithMap("/types/set", testXmlString));
+    }
+
+    @Test
     void shouldHandleEncodingTypesWithNamedTypes() throws Exception
     {
         try (InputStream in = Tests.getLocalResource("encoding-types-schema.xml"))


### PR DESCRIPTION
A `<choice>` value is a bit position and must be in `[0, size * 8)`. The bounds check only guarded the upper limit, so a negative value (e.g. `-1`) passed schema validation and was later emitted as a shift amount in generated code, where `1 << -1` is silently masked to `1 << 31` — producing wrong encode/decode masking for an invalid schema.

Reject negative values too (`value < 0 || value >= size * 8`). Added a test symmetric to the existing upper-bound one.