### PR TITLE
[C++] Expose schema version from IrDecoder

### DIFF
--- a/sbe-tool/src/main/cpp/otf/IrDecoder.h
+++ b/sbe-tool/src/main/cpp/otf/IrDecoder.h
@@ -141,6 +141,10 @@ public:
         return m_id;
     }
 
+    int schemaVersion() const {
+        return m_version;
+    }
+
 protected:
     // OS specifics
     static long long getFileSize(const char *filename)
@@ -188,6 +192,7 @@ private:
     std::unique_ptr<char[]> m_buffer;
     std::uint64_t m_length = 0;
     int m_id = 0;
+    int m_version = 0;
 
     int decodeIr()
     {
@@ -221,6 +226,7 @@ private:
         std::uint64_t headerLength = readHeader(offset);
 
         m_id = frame.irId();
+        m_version = frame.schemaVersion();
 
         offset += headerLength;
 

--- a/sbe-tool/src/test/cpp/VersionedMessageTest.cpp
+++ b/sbe-tool/src/test/cpp/VersionedMessageTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "otf/IrDecoder.h"
 #include "versmsg/VersionedMessageV1.h"
 #include "versmsg/VersionedMessageV2.h"
 
@@ -54,4 +55,13 @@ TEST_F(VersionedMessageTest, shouldV1DecodeV2Message)
     EXPECT_STREQ(m_versionedMessageV1Decoder.string1(), "asdf");
 
     EXPECT_EQ(m_versionedMessageV1Decoder.decodeLength(), (uint64_t)26);
+}
+
+TEST_F(VersionedMessageTest, shouldExposeSchemaVersionFromIr)
+{
+    IrDecoder irDecoder = {};
+
+    ASSERT_GE(irDecoder.decode("versioned-message-v2.sbeir"), 0);
+    EXPECT_EQ(irDecoder.schemaId(), 1);
+    EXPECT_EQ(irDecoder.schemaVersion(), 2);
 }


### PR DESCRIPTION
Expose the schema version carried by the IR frame through the C++ IrDecoder.

The regression test decodes the versioned V2 IR and checks both the schema id and schema version.

Tested with:
- `VersionedMessageTest`

Fixes #1059.