### PR TITLE
Add setRaw() method for Set type encoder (#1086)

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -1902,11 +1902,11 @@ public class JavaGenerator implements CodeGenerator
         final String encoderName = encoderName(bitSetName);
         final List<Token> choiceList = tokens.subList(1, tokens.size() - 1);
         final String implementsString = implementsInterface(Flyweight.class.getSimpleName());
+        final Encoding encoding = token.encoding();
 
         registerTypesPackageName(token, ir);
         try (Writer out = outputManager.createOutput(decoderName))
         {
-            final Encoding encoding = token.encoding();
             generateFixedFlyweightHeader(
                 out, token, decoderName, implementsString, readOnlyBuffer, fqReadOnlyBuffer, PACKAGES_EMPTY_SET);
             out.append(generateChoiceIsEmpty(encoding.primitiveType()));
@@ -1931,6 +1931,18 @@ public class JavaGenerator implements CodeGenerator
             generateFixedFlyweightHeader(
                 out, token, encoderName, implementsString, mutableBuffer, fqMutableBuffer, PACKAGES_EMPTY_SET);
             generateChoiceClear(out, encoderName, token);
+
+            new Formatter(out).format(
+                    "\n" +
+                            "    public %s setRaw(final %s value)\n" +
+                            "    {\n" +
+                            "        %s;\n" +
+                            "        return this;\n" +
+                            "    }\n",
+                    encoderName,
+                    primitiveTypeName(token),
+                    generatePut(encoding.primitiveType(), "offset", "value", byteOrderString(encoding)));
+
             generateChoiceEncoders(out, encoderName, choiceList);
             out.append("}\n");
         }

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
@@ -399,16 +399,11 @@ class JavaGeneratorTest
         final Class<?> rawType = getRawMethod.getReturnType();
         final Method setRawMethod = extrasEncoder.getClass().getMethod("setRaw", rawType);
 
-        final byte rawValue = (byte)0b0000_0101;
-        final Object boxedValue =
-                rawType == byte.class ? (Object)rawValue :
-                        rawType == short.class ? (Object)(short)rawValue :
-                                (Object)(int)rawValue;
-
+        final Short boxedValue = (short)0b0000_0101;
         setRawMethod.invoke(extrasEncoder, boxedValue);
 
         final Object result = getRawMethod.invoke(extrasDecoder);
-        assertEquals(rawValue, ((Number)result).byteValue());
+        assertEquals(boxedValue, result);
     }
 
     @Test

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
@@ -383,6 +383,35 @@ class JavaGeneratorTest
     }
 
     @Test
+    void shouldGenerateBitSetRawAccessor() throws Exception
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
+
+        generator().generate();
+
+        final Object encoder = wrap(buffer, compileCarEncoder().getConstructor().newInstance());
+        final Object decoder = getCarDecoder(buffer, encoder);
+
+        final Object extrasEncoder = getExtras(encoder);
+        final Object extrasDecoder = getExtras(decoder);
+
+        final Method getRawMethod = extrasDecoder.getClass().getMethod("getRaw");
+        final Class<?> rawType = getRawMethod.getReturnType();
+        final Method setRawMethod = extrasEncoder.getClass().getMethod("setRaw", rawType);
+
+        final byte rawValue = (byte)0b0000_0101;
+        final Object boxedValue =
+                rawType == byte.class ? (Object)rawValue :
+                        rawType == short.class ? (Object)(short)rawValue :
+                                (Object)(int)rawValue;
+
+        setRawMethod.invoke(extrasEncoder, boxedValue);
+
+        final Object result = getRawMethod.invoke(extrasDecoder);
+        assertEquals(rawValue, ((Number)result).byteValue());
+    }
+
+    @Test
     void shouldGenerateEnumCodecs() throws Exception
     {
         final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);


### PR DESCRIPTION
## Problem
`getRaw()` is generated in the decoder for `Set` (bitset) types, but the
symmetric `setRaw()` method is missing from the generated encoder,
preventing direct writes of a raw bitset value without going through
individual choice setters.

Fixes #1086

## Solution
Added generation of `setRaw()` in `JavaGenerator#generateBitSet`, mirroring
the existing `getRaw()` decoder logic, using the same `generatePut`
mechanism already used elsewhere in the generator.

## Testing
Added `shouldGenerateBitSetRawAccessor` in `JavaGeneratorTest`, which
encodes a raw value via `setRaw()` and verifies it round-trips correctly
through the existing `getRaw()` decoder method.

All existing tests pass, including `shouldGenerateBitSetCodecs`.